### PR TITLE
Updated to use recent libgee

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -22,18 +22,18 @@ AM_PROG_VALAC
 PKG_PROG_PKG_CONFIG
 
 # Checks for libraries.
-libsubmarine_modules="glib-2.0 gobject-2.0 libsoup-2.4 gee-1.0 libarchive libxml-2.0"
+libsubmarine_modules="glib-2.0 gobject-2.0 libsoup-2.4 gee-0.8 libarchive libxml-2.0"
 PKG_CHECK_MODULES([LIBSUBMARINE], [$libsubmarine_modules])
 AC_SUBST([LIBSUBMARINE_CFLAGS])
 AC_SUBST([LIBSUBMARINE_LIBS])
-LIBSUBMARINE_VALAPACKAGES="--pkg gee-1.0 --pkg libsoup-2.4 --pkg libarchive --pkg libxml-2.0"
+LIBSUBMARINE_VALAPACKAGES="--pkg gee-0.8 --pkg libsoup-2.4 --pkg libarchive --pkg libxml-2.0"
 AC_SUBST([LIBSUBMARINE_VALAPACKAGES])
 
 submarine_modules="$libsubmarine_modules gio-2.0"
 PKG_CHECK_MODULES([SUBMARINE], [$submarine_modules])
 AC_SUBST([SUBMARINE_CFLAGS])
 AC_SUBST([SUBMARINE_LIBS])
-SUBMARINE_VALAPACKAGES="--pkg gee-1.0 --pkg gio-2.0"
+SUBMARINE_VALAPACKAGES="--pkg gee-0.8 --pkg gio-2.0"
 AC_SUBST([SUBMARINE_VALAPACKAGES])
 
 AC_OUTPUT


### PR DESCRIPTION
Hello, as libgee is now using pkg-config file numbered with 0.8 whereas it was using 1.0 beore libgee-0.7 I add to modified configure.ac to build on my mac.

XL.
